### PR TITLE
Prevent `KeyError` when reading self.attributes

### DIFF
--- a/custom_components/prusa_connect/sensor.py
+++ b/custom_components/prusa_connect/sensor.py
@@ -64,7 +64,7 @@ class PrusaSensor(Entity):
     @property
     def state(self):
         # return sensor value to home assistant
-        return self.inst.attributes[self.v_name]
+        return self.inst.attributes.get(self.v_name, None)
 
     def update(self):
         # request backend upgrade, but only when called from one instance


### PR DESCRIPTION
This partially solves the issue for me: It's starting now, but no `time_tts` entity is showing up.
Let me know if you have any objections or need further infromation!

fixes #2