### PR TITLE
Fixed warning message in log.

### DIFF
--- a/custom_components/prusa_connect/manifest.json
+++ b/custom_components/prusa_connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "prusa_connect",
   "name": "Prusa Connect",
-  "version": "1.4a",
+  "version": "1.4.1",
   "documentation": "https://github.com/sq3tle/prusa_mini_home_assistant/blob/main/README.md",
   "issue_tracker": "https://github.com/sq3tle/prusa_mini_home_assistant/issues",
   "codeowners": ["@sq3tle"],


### PR DESCRIPTION
```WARNING (MainThread) [homeassistant.loader] '1.4a' is not a valid version for custom integration 'prusa_connect'. Please report this to the maintainer of 'prusa_connect'```
